### PR TITLE
Delete duplicate SERVICE_ALERT, HOST_ALERT

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -146,10 +146,6 @@ class InfluxdbBroker(BaseModule):
             )
         )
 
-        post_data.extend(
-            self.get_state_update_points(b.data, name)
-        )
-
         try:
             logger.debug("[influxdb broker] Launching: %s" % str(post_data))
         except UnicodeEncodeError:
@@ -170,10 +166,6 @@ class InfluxdbBroker(BaseModule):
                 b.data['last_chk'],
                 name
             )
-        )
-
-        post_data.extend(
-            self.get_state_update_points(b.data, name)
         )
 
         try:


### PR DESCRIPTION
Hello !

I just try this module, I saw  duplicate event in `_events_`:

| time | sequence_number | alert_type | attempts | state_type | state | output |
| --- | --- | --- | --- | --- | --- | --- |
| 1414537758000 | 4180001 | SERVICE | 1 | HARD | OK | SSH OK - OpenSSH_6.6.1p1 Ubuntu-2ubuntu2 (protocol 2.0) |
| 1414537757000 | 4190001 |  |  | HARD | OK | SSH OK - OpenSSH_6.6.1p1 Ubuntu-2ubuntu2 (protocol 2.0) |
| 1414536258000 | 290001 |  |  | HARD | CRITICAL | Connection refused |
| 1414536258000 | 280001 | SERVICE | 1 | HARD | CRITICAL | Connection refused |
| 1414536199000 | 30001 | SERVICE | 1 | SOFT | CRITICAL | Connection refused |
| 1414536198000 | 40001 |  |  | SOFT | CRITICAL | Connection refused |

Delete this lines correct this.
BUT maybe there is some side effects.
What do you think about ?

Anyway, we have to think about Travis tests and.
