### PR TITLE
Fixed KeyError with no supported event types

### DIFF
--- a/module/logevent.py
+++ b/module/logevent.py
@@ -77,7 +77,9 @@ class LogEvent:
 
         if event_type_match:
             #parse it with it's pattern
-            event_type = event_types[event_type_match.group(1)]
+            event_type = event_types.get(event_type_match.group(1), None)
+            if event_type is None:
+                return
             properties_match = re.match(event_type['pattern'], log)
 
             if properties_match:


### PR DESCRIPTION
Exception is raised with no supported event types, like FLAPPING one.

```
2014-11-13 12:38:56,235 [1415878736] Warning : [broker-master] Back trace of this kill: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/shinken/daemons/brokerdaemon.py", line 245, in manage_brok
    mod.manage_brok(b)
  File "/usr/local/lib/python2.7/dist-packages/shinken/basemodule.py", line 236, in manage_brok
    return manage(brok)
  File "/var/lib/shinken/modules/mod-influxdb/module.py", line 239, in manage_log_brok
    event = LogEvent(log)
  File "/var/lib/shinken/modules/mod-influxdb/logevent.py", line 80, in __init__
    event_type = event_types[event_type_match.group(1)]
KeyError: u'FLAPPING'
```

This patch avoids module crashes with a safety check. But please, consider adding support for FLAPPING and EVENT types filling the event_types dict accordingly or drop the option in the main event_type_pattern regexp.
